### PR TITLE
revolution1 - 지뢰판에서의 메모 표식 가독성 개선

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -148,7 +148,7 @@ void InitArea(SetInfo setInfo) {
 			return;
 		}
 	}
-	
+
 	//구조체 배열의 멤버 값을 초기화한다.
 	for (i = 0; i < setInfo.len; i++) {
 		for (j = 0; j < setInfo.col; j++) {
@@ -262,7 +262,7 @@ void bfs(SetInfo setInfo, int x, int y, int* visi) {
 }
 
 void print(int c, SetInfo setInfo) {
-	char p[] = { ' ', 'O', 'X', '_' };
+	char p[] = { ' ', 'S', 'X', '?' }; //  기존의 'O', '_'를 각각 'S', '?'로 변경하였습니다.
 	int x, y;
 	char mineNumToChar;
 
@@ -291,7 +291,7 @@ void print(int c, SetInfo setInfo) {
 						mineNumToChar = (char)areaInfo[x][y].mineNum + '0';
 						printf("%-2c", mineNumToChar);
 					}
-						
+
 				}
 				else
 					printf("%-2c", p[Mark(x, y)]);


### PR DESCRIPTION
기존의 코드에서 메모에 사용되던 표식들이 게임을 진행하는 데 헷갈리게 하는 부분이 있어, 수정하였습니다.  SAFE를 표시하는 표식을 'O'에서 'S'로 수정하였고 '_' 표식은 '?' 표식으로 수정하였습니다.